### PR TITLE
LLC logo deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-<div align="center">
-<a href="https://github.com/LocalizeLimbusCompany/LocalizeLimbusCompany">
-   <img src="https://avatars.githubusercontent.com/u/129521269" />
-</a>
-
 # LLC_ModCompatible
 二改版零协汉化模组，移除模组检测机制
 


### PR DESCRIPTION
LLC Logo并不是开源项目的一部分，我们享有对其的著作权。
如果您决定移除检测部分，我们则希望您不要同时使用我们的logo。

另，相同功能的项目在[Nexus Mods](https://www.nexusmods.com/limbuscompany/mods/54)上已有用户上传。